### PR TITLE
fix: prevent incompatible hkl volume start,stop,step

### DIFF
--- a/CLI/i07/runconfig.py
+++ b/CLI/i07/runconfig.py
@@ -69,12 +69,18 @@ if __name__ == "__main__":
         rlist=eval(args.scan_range)
         if len(np.shape(rlist))==1:
             scanrange=rlist
-            SCANS=list(range(int(scanrange[0]),int(scanrange[1])+1,int(scanrange[2])))
+            SCANS=list(range(
+                int(scanrange[0]),
+                int(scanrange[1])+1,
+                int(scanrange[2])))
         else:
             SCANS=[]
             for r in rlist:
                 scanrange=r
-                SCANS.extend(list(range(int(scanrange[0]),int(scanrange[1])+1,int(scanrange[2]))))
+                SCANS.extend(list(range(
+                    int(scanrange[0]),
+                    int(scanrange[1])+1,
+                    int(scanrange[2]))))
 
 
     i=1
@@ -88,16 +94,16 @@ if __name__ == "__main__":
         save_path = Path(OUTDIR)/Path(save_file_name)
         if i > 1e7:
             raise ValueError(
-                "naming counter hit limit therefore exiting ")   
-    
+                "naming counter hit limit therefore exiting ")
+
     #save variables to job file using job template
     f=open(save_path,'x')
     f.write(''.join(lines1))
     f.write(f'scan_numbers= {SCANS}\n')
     f.write(''.join(lines2))
     f.close()
-    
-    
+
+
     #load in template mapscript, new paths
     f=open(f'{Path.home()}/fast_rsm/mapscript_template.sh')
     lines=f.readlines()
@@ -166,6 +172,3 @@ if __name__ == "__main__":
             print("error encountered during processing, view slurm file for details")
             #subprocess.run([f"less {Path.home()}/fast_rsm/{endslurms[-1]}"])
             #os.system(f"less {Path.home()}/fast_rsm/{endslurms[-1]}")
-
-
-

--- a/src/fast_rsm/binning.py
+++ b/src/fast_rsm/binning.py
@@ -34,9 +34,8 @@ def finite_diff_shape(start: np.ndarray, stop: np.ndarray, step: np.ndarray):
     to store data with this start, stop and step.
     """
     return (
-        len(np.arange(start[0], stop[0], step[0])),
-        len(np.arange(start[1], stop[1], step[1])),
-        len(np.arange(start[2], stop[2], step[2]))
+        tuple(int(np.ceil(_stop/_step)) - int(np.floor(_start/_step)) + 1
+         for (_start, _stop, _step) in zip(start, stop, step))
     )
 
 

--- a/src/fast_rsm/binning.py
+++ b/src/fast_rsm/binning.py
@@ -28,15 +28,19 @@ def _fix_intensity_geometry(arr: np.ndarray) -> np.ndarray:
     return arr
 
 
+def finite_diff_grid(start: np.ndarray, stop: np.ndarray, step: np.ndarray):
+    """
+    Works out the shape of the finite differences grid and returns it.
+    """
+    return tuple(np.arange(start[i], stop[i], step[i]) for i in range(3))
+
+
 def finite_diff_shape(start: np.ndarray, stop: np.ndarray, step: np.ndarray):
     """
     Works out the shape of the finite differences grid that we're going to need
     to store data with this start, stop and step.
     """
-    return (
-        tuple(int(np.ceil(_stop/_step)) - int(np.floor(_start/_step)) + 1
-         for (_start, _stop, _step) in zip(start, stop, step))
-    )
+    return tuple(len(arr) for arr in finite_diff_grid(start, stop, step))
 
 
 def linear_bin(coords: np.ndarray,  # Coordinates of each intensity.

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -418,12 +418,12 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     volume = np.nan_to_num(volume)
 
     # Make h, k and l arrays in the expected format.
-    h_arr = np.array([0, start[0], stop[0], step[0],
-                      start[0]/step[0], stop[0]/step[0]])
-    k_arr = np.array([1, start[1], stop[1], step[1],
-                      start[1]/step[1], stop[1]/step[1]])
-    l_arr = np.array([2, start[2], stop[2], step[2],
-                      start[2]/step[2], stop[2]/step[2]])
+    h_arr, k_arr, l_arr = (
+        tuple(np.array([i, start[i], stop[i], step[i],
+                        int(np.floor(start[i]/step[i])),
+                        int(np.ceil(stop[i]/step[i]))])
+              for i in range(3))
+    )
 
     # Turn those into an axes group.
     axes_group = nx.NXgroup(h=h_arr, k=k_arr, l=l_arr)

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -421,14 +421,22 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     # internally, the used grid is defined by np.arange(start, stop, step)
     # which may be missing the last element!
     true_grid = finite_diff_grid(start, stop, step)
-    true_start = [interval[0] for interval in true_grid]
-    true_stop = [interval[-1] for interval in true_grid]
+    binoculars_step = step
+    binoculars_start = [interval[0] for interval in true_grid]
+    binoculars_start_int = [int(np.floor(start[i]/step[i])) for i in range(3)]
+    binoculars_stop_int = [
+        int(binoculars_start_int[i] + volume.shape[i])
+        for i in range(3)
+        ]
+    binoculars_stop = [binoculars_stop_int[i]*binoculars_step[i]
+                       for i in range(3)]
 
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (
-        tuple(np.array([i, true_start[i], true_stop[i], step[i],
-                        int(np.floor(true_start[i]/step[i])),
-                        int(np.ceil(true_stop[i]/step[i]))])
+        tuple(np.array([i, binoculars_start[i], binoculars_stop[i],
+                        binoculars_step[i],
+                        float(binoculars_start_int[i])+0.01,  # binoculars
+                        float(binoculars_stop_int[i])-0.01])  # uses np.floor,ceil
               for i in range(3))
     )
 

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -12,7 +12,7 @@ from scipy.constants import physical_constants
 
 import nexusformat.nexus as nx
 
-from .binning import weighted_bin_1d
+from .binning import weighted_bin_1d, finite_diff_grid
 
 
 def load_exact_map(
@@ -417,11 +417,18 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     contributions[~np.isnan(volume)] = 1
     volume = np.nan_to_num(volume)
 
+    # make sure to use consistent conventions for the grid.
+    # internally, the used grid is defined by np.arange(start, stop, step)
+    # which may be missing the last element!
+    true_grid = finite_diff_grid(start, stop, step)
+    true_start = true_grid[0, 0, 0]
+    true_stop = true_grid[1, 1, 1]
+
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (
-        tuple(np.array([i, start[i], stop[i], step[i],
-                        int(np.floor(start[i]/step[i])),
-                        int(np.ceil(stop[i]/step[i]))])
+        tuple(np.array([i, true_gridstart[i], true_gridstop[i], step[i],
+                        int(np.floor(true_gridstart[i]/step[i])),
+                        int(np.ceil(true_gridstop[i]/step[i]))])
               for i in range(3))
     )
 

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -421,8 +421,8 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     # internally, the used grid is defined by np.arange(start, stop, step)
     # which may be missing the last element!
     true_grid = finite_diff_grid(start, stop, step)
-    true_start = true_grid[0, 0, 0]
-    true_stop = true_grid[1, 1, 1]
+    true_start = (interval[0] for interval in true_grid)
+    true_stop = (interval[1] for interval in true_grid)
 
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -425,7 +425,7 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     binoculars_start = [interval[0] for interval in true_grid]
     binoculars_start_int = [int(np.floor(start[i]/step[i])) for i in range(3)]
     binoculars_stop_int = [
-        int(binoculars_start_int[i] + volume.shape[i])
+        int(binoculars_start_int[i] + volume.shape[i] - 1)
         for i in range(3)
         ]
     binoculars_stop = [binoculars_stop_int[i]*binoculars_step[i]
@@ -435,8 +435,8 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     h_arr, k_arr, l_arr = (
         tuple(np.array([i, binoculars_start[i], binoculars_stop[i],
                         binoculars_step[i],
-                        float(binoculars_start_int[i])+0.01,  # binoculars
-                        float(binoculars_stop_int[i])-0.01])  # uses np.floor,ceil
+                        float(binoculars_start_int[i]),  # binoculars
+                        float(binoculars_stop_int[i])])  # uses int()
               for i in range(3))
     )
 

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -426,9 +426,9 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
 
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (
-        tuple(np.array([i, true_gridstart[i], true_gridstop[i], step[i],
-                        int(np.floor(true_gridstart[i]/step[i])),
-                        int(np.ceil(true_gridstop[i]/step[i]))])
+        tuple(np.array([i, true_start[i], true_stop[i], step[i],
+                        int(np.floor(true_start[i]/step[i])),
+                        int(np.ceil(true_stop[i]/step[i]))])
               for i in range(3))
     )
 

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -422,7 +422,7 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     # which may be missing the last element!
     true_grid = finite_diff_grid(start, stop, step)
     true_start = [interval[0] for interval in true_grid]
-    true_stop = [interval[1] for interval in true_grid]
+    true_stop = [interval[-1] for interval in true_grid]
 
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (

--- a/src/fast_rsm/diamond_utils.py
+++ b/src/fast_rsm/diamond_utils.py
@@ -421,8 +421,8 @@ def save_binoculars_hdf5(path_to_npy: np.ndarray, output_path: str):
     # internally, the used grid is defined by np.arange(start, stop, step)
     # which may be missing the last element!
     true_grid = finite_diff_grid(start, stop, step)
-    true_start = (interval[0] for interval in true_grid)
-    true_stop = (interval[1] for interval in true_grid)
+    true_start = [interval[0] for interval in true_grid]
+    true_stop = [interval[1] for interval in true_grid]
 
     # Make h, k and l arrays in the expected format.
     h_arr, k_arr, l_arr = (

--- a/src/fast_rsm/experiment.py
+++ b/src/fast_rsm/experiment.py
@@ -647,19 +647,19 @@ def _match_start_stop_to_step(
     if user_bounds == (None, None):
         # use auto bounds and expand both ways
         diff = _clean_mod(auto_bounds[1] - auto_bounds[0], step)
-        if np.any(diff > eps):
+        if np.any(diff < eps):
             return auto_bounds[0], auto_bounds[1]
         return auto_bounds[0] - diff/2, auto_bounds[1] + diff/2
     elif user_bounds[0] is None:
         # keep user value and expand to right
         diff = _clean_mod(user_bounds[1] - auto_bounds[0], step)
-        if np.any(diff > eps):
+        if np.any(diff < eps):
             return auto_bounds[0], user_bounds[1]
         return auto_bounds[0] - diff, user_bounds[1]
     elif user_bounds[1] is None:
         # keep user value and expand to left
         diff = _clean_mod(auto_bounds[1] - user_bounds[0], step)
-        if np.any(diff > eps):
+        if np.any(diff < eps):
             return user_bounds[0], auto_bounds[1]
         return user_bounds[0], auto_bounds[1] + diff
     else:

--- a/src/fast_rsm/experiment.py
+++ b/src/fast_rsm/experiment.py
@@ -647,24 +647,24 @@ def _match_start_stop_to_step(
     if user_bounds == (None, None):
         # use auto bounds and expand both ways
         diff = _clean_mod(auto_bounds[1] - auto_bounds[0], step)
-        if diff < eps:
+        if np.any(diff > eps):
             return auto_bounds[0], auto_bounds[1]
         return auto_bounds[0] - diff/2, auto_bounds[1] + diff/2
     elif user_bounds[0] is None:
         # keep user value and expand to right
         diff = _clean_mod(user_bounds[1] - auto_bounds[0], step)
-        if diff < eps:
+        if np.any(diff > eps):
             return auto_bounds[0], user_bounds[1]
         return auto_bounds[0] - diff, user_bounds[1]
     elif user_bounds[1] is None:
         # keep user value and expand to left
         diff = _clean_mod(auto_bounds[1] - user_bounds[0], step)
-        if diff < eps:
+        if np.any(diff > eps):
             return user_bounds[0], auto_bounds[1]
         return user_bounds[0], auto_bounds[1] + diff
     else:
         diff = _clean_mod(user_bounds[1] - user_bounds[0], step)
-        if diff > eps:
+        if np.any(diff > eps):
             raise ValueError("Provided values for reciprocal value start, "
                             "stop and step that are incompatible. Please make "
                             "sure that the boundaries fulfill volume_start -"

--- a/src/fast_rsm/experiment.py
+++ b/src/fast_rsm/experiment.py
@@ -223,7 +223,7 @@ class Experiment:
         else:
             step = np.array(volume_step)
             _start, _stop = self.q_bounds(map_frame, oop)
-            start, stop = match_start_stop_to_step(
+            start, stop = _match_start_stop_to_step(
                 step=step,
                 user_bounds=(volume_start, volume_stop),
                 auto_bounds=(_start, _stop))

--- a/src/fast_rsm/writing.py
+++ b/src/fast_rsm/writing.py
@@ -19,7 +19,7 @@ def linear_bin_to_vtk(binned_data: np.ndarray,
 
     # Coordinates
     x_range, y_range , z_range = tuple(
-        np.linspace(start[i], stop[i], num=binned_data.shape[i],
+        np.linspace(start[i], stop[i]+step[i], num=binned_data.shape[i],
                     dtype=np.float32) for i in range(3)
     )
 

--- a/src/fast_rsm/writing.py
+++ b/src/fast_rsm/writing.py
@@ -2,6 +2,7 @@
 This module contains convenience functions for writing reciprocal space maps.
 """
 
+
 import numpy as np
 from pyevtk.hl import gridToVTK
 
@@ -18,10 +19,21 @@ def linear_bin_to_vtk(binned_data: np.ndarray,
     file_path = str(file_path)
 
     # Coordinates
-    x_range, y_range , z_range = tuple(
-        np.linspace(start[i], stop[i]+step[i], num=binned_data.shape[i],
-                    dtype=np.float32) for i in range(3)
-    )
+
+    x_range = np.arange(start[0], stop[0], step[0], dtype="float32")
+    x_range = list(x_range)
+    x_range.append(stop[0])
+    x_range = np.array(x_range, dtype=np.float32)
+
+    y_range = np.arange(start[1], stop[1], step[1], dtype="float32")
+    y_range = list(y_range)
+    y_range.append(stop[1])
+    y_range = np.array(y_range, dtype=np.float32)
+
+    z_range = np.arange(start[2], stop[2], step[2], dtype="float32")
+    z_range = list(z_range)
+    z_range.append(stop[2])
+    z_range = np.array(z_range, dtype=np.float32)
 
     gridToVTK(file_path, x_range, y_range, z_range,
               cellData={"Intensity": binned_data})

--- a/src/fast_rsm/writing.py
+++ b/src/fast_rsm/writing.py
@@ -2,7 +2,6 @@
 This module contains convenience functions for writing reciprocal space maps.
 """
 
-
 import numpy as np
 from pyevtk.hl import gridToVTK
 
@@ -19,20 +18,10 @@ def linear_bin_to_vtk(binned_data: np.ndarray,
     file_path = str(file_path)
 
     # Coordinates
-    x_range = np.arange(start[0], stop[0], step[0], dtype="float32")
-    x_range = list(x_range)
-    x_range.append(stop[0])
-    x_range = np.array(x_range, dtype=np.float32)
-
-    y_range = np.arange(start[1], stop[1], step[1], dtype="float32")
-    y_range = list(y_range)
-    y_range.append(stop[1])
-    y_range = np.array(y_range, dtype=np.float32)
-
-    z_range = np.arange(start[2], stop[2], step[2], dtype="float32")
-    z_range = list(z_range)
-    z_range.append(stop[2])
-    z_range = np.array(z_range, dtype=np.float32)
+    x_range, y_range , z_range = tuple(
+        np.linspace(start[i], stop[i], num=binned_data.shape[i],
+                    dtype=np.float32) for i in range(3)
+    )
 
     gridToVTK(file_path, x_range, y_range, z_range,
               cellData={"Intensity": binned_data})


### PR DESCRIPTION
Currently, when the user defines the volume_step parameter, but leaves the volume_start and volume_stop undefined, a situation may occur in which the automatically chosen start and end points do not fulfill volume_stop - volume_start = volume_step*integer.
If this happens, the reciprocal space mapping will still currently succeed, but the voxel positions in reciprocal space are ill-defined, and an error may occur when trying to read the file in BINoculars.